### PR TITLE
 DBCS aware uppercase in DOS_MakeName

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -62,6 +62,20 @@ void DOS_SetDefaultDrive(Bit8u drive) {
 	if (drive<=DOS_DRIVES && ((drive<2) || Drives[drive])) {dos.current_drive = drive; DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDrive(drive);}
 }
 
+static bool DBCS_LeadByte(Bit8u c) {
+	int i;
+	Bit16u pair;
+	for (i = 0;; i++) {
+		Bit8u cstart, cend;
+		pair = mem_readw(Real2Phys(dos.tables.dbcs) + 0x02 + i*2);
+		if (!pair) break;
+		cstart = pair;
+		cend = pair >> 8;
+		if ((cstart <= c) && (c <= cend)) return true;
+	}
+	return false;
+}
+
 bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	if(!name || *name == 0 || *name == ' ') {
 		/* Both \0 and space are seperators and
@@ -106,11 +120,15 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	r=0;w=0;
 	while (name_int[r]!=0 && (r<DOS_PATHLENGTH)) {
 		c=name_int[r++];
-		//if ((c>='a') && (c<='z')) c-=32;
+		if ((c>='a') && (c<='z')) c-=32;
 		if (c=='"') {q++;continue;}
 		else if (c=='/') c='\\';
 		else if (c==' ' && q/2*2 == q) break; /* should be separator */
 		upname[w++]=c;
+		if (DBCS_LeadByte(c)) {
+			// skip DBCS 2nd byte
+			upname[w++] = name_int[r++];
+		}
 	}
 	while (r>0 && name_int[r-1]==' ') r--;
 	if (r>=DOS_PATHLENGTH) { DOS_SetError(DOSERR_PATH_NOT_FOUND);return false; }

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -64,8 +64,8 @@ void DOS_SetDefaultDrive(Bit8u drive) {
 
 static bool DBCS_LeadByte(Bit8u c) {
 	int i;
-	Bit16u pair;
 	for (i = 0;; i++) {
+		Bit16u pair;
 		Bit8u cstart, cend;
 		pair = mem_readw(Real2Phys(dos.tables.dbcs) + 0x02 + i*2);
 		if (!pair) break;

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -927,8 +927,6 @@ char * DOS_Shell::Which(char * name) {
 	/* Check if name is already ok but just misses an extension */
 
 	if (DOS_FileExists(name)) return name;
-	upcase(name);
-	if (DOS_FileExists(name)) return name;
 	/* try to find .com .exe .bat */
 	strcpy(which_ret,name);
 	strcat(which_ret,com_ext);


### PR DESCRIPTION
# 大文字小文字区別のあるシステム上での問題

Dosbox-LFN の問題だとは思いますが、Linux上で DOSVAXJ3 を使用していると、大文字小文字に起因していると考えられる、 LFN パッチが適用されていない Dosbox では起こらない問題が発生しています。

1. マウント先のローカルでのファイル名が大文字であるとき、環境変数 PATH が小文字で記述されていると環境変数部が大文字に変換されずに PATH 内の実行ファイルが見つけられず失敗する。
2. (PATH を大文字に設定していても) OpenWatcom で `wcl` が途中でハングアップしたり、内部で呼び出している `wlink` などが見つけられずに異常終了したり、 DOS/4GW が見つけられずに起動に失敗したりする。

原因としてですが、
* LFN 化が適用されていない DosBox では、 `DOS_MakeName` 内で大文字変換されることによって `DOS_Shell::Which` により PATH を検索するアルゴリズムで、localDrive 側などに渡されるファイル名が必ず大文字であることが保証されていたため問題が発生していない。
* LFN パッチでは、 `DOS_MakeName` 内の大文字化部がコメントアウトされている。
  既存の大文字化は DBCS どころか ASCII 以外全く考慮されていないものなので削除された? (大文字小文字を区別しない Windows などの)OS側に任せる考えと思われる
* `DOS_Shell::Which` 内で、最初の方で `upcase(name);` している。
https://www.vogons.org/viewtopic.php?f=41&t=40610&start=60#p442657 で修正?
但し、 PATH 変数から取ってきた部分までは大文字化されないので問題となる。また、 `upcase` なので DBCS には対応していない。
(例: `> vi` を実行すると、 `C:\bin\VI.EXE` -> `/dosboxdrv/bin/VI.EXE` となり ( `BIN` ではなく `bin` という存在しないパスとなり) 失敗する。)

ファイルシステム上の大文字小文字に依らずきちんと対応するには、 Wine などを参考にしないといけない可能性がありますが、参考までに簡易的な修正点を Pull request で作成してみました。PC-98 DOS 環境互換を目指している DosBox-X を参考にしました。(https://github.com/joncampbell123/dosbox-x/blob/04aa151e786adbd5581c2919df8d2ece5052ea1d/src/dos/dos_files.cpp#L89) 全角文字は大文字化していない点は、実際の DOS と同じです。 (http://elm-chan.org/docs/fat.html#lfn_comp)